### PR TITLE
fixed potential typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ var build = 'var mytemplate = '+ jsx.client(template).toString();
 The `.toString()` method automatically transforms the function in to an
 anonymous function. In the example above we saved the template as `mytemplate`
 variable. So when we store this a JavaScript file to disk using a
-`fs.writeFileSync('/mytemplate.js', mytemplate);` we can easily access the
+`fs.writeFileSync('/mytemplate.js', build);` we can easily access the
 template on the client side by referencing the `mytemplate` global.
 
 So with this knowledge, an illustration of this:


### PR DESCRIPTION
I'm not sure if this was intentional but I believe this was a typo in the example with the variable name. It left me confused for a while.
