### PR TITLE
React 14:  switch to Babel and ReactDOM

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/bigpipe/react-jsx",
   "dependencies": {
-    "react": "0.12.2"
+    "react": "0.14.x"
   }
 }

--- a/fixtures/advanced.jsx
+++ b/fixtures/advanced.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 <div>
   <input type="text" value={defaultValue} />
   <button onclick="alert('clicked!');">Click Me!</button>

--- a/fixtures/component.jsx
+++ b/fixtures/component.jsx
@@ -1,3 +1,1 @@
-/** @jsx React.DOM */
-
 <Hello name={namethings('john')} />

--- a/fixtures/react.jsx
+++ b/fixtures/react.jsx
@@ -1,3 +1,1 @@
-/** @jsx React.DOM */
-
 <div>content</div>;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var compiler = require('babel-core')
+var compiler = require('babel-standalone')
   , React = require('react')
   , ReactDOM = require('react-dom/server');
 /**

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/bigpipe/react-jsx",
   "dependencies": {
-    "babel-core": "^6.5.2",
     "babel-preset-react": "^6.5.0",
+    "babel-standalone": "^6.4.4",
     "react": "0.14.x",
     "react-dom": "^0.14.7"
   },

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   },
   "homepage": "https://github.com/bigpipe/react-jsx",
   "dependencies": {
-    "react": "0.13.x",
-    "react-tools": "0.13.x"
+    "babel-core": "^6.5.2",
+    "babel-preset-react": "^6.5.0",
+    "react": "0.14.x",
+    "react-dom": "^0.14.7"
   },
   "devDependencies": {
     "assume": "1.1.x",

--- a/test.js
+++ b/test.js
@@ -8,6 +8,7 @@ describe('react-jsx', function () {
 
   var assume = require('assume')
     , React = require('react')
+    , ReactDOM = require('react-dom/server')
     , path = require('path')
     , jsx = require('./')
     , fs = require('fs')
@@ -36,6 +37,7 @@ describe('react-jsx', function () {
   describe('.client', function () {
     before(function () {
       global.React = require('react');
+      global.ReactDOM = require('react-dom/server');
     });
 
     it('is exported as a function', function () {
@@ -72,6 +74,7 @@ describe('react-jsx', function () {
   describe('.server', function () {
     before(function () {
       delete global.React;
+      delete global.ReactDOM;
     });
 
     it('is exported as a function', function () {


### PR DESCRIPTION
Due to deprecations beginning with react@0.14 (`react-tools` is out and the DOM render methods now are found in `react-dom` package), I've made the following changes:
- update dependency to react 0.14.x 
- use babel (`babel-core` with the react preset) in place of `react-tools` (see https://github.com/bigpipe/react-jsx/issues/5)
- import `react-dom/server` for rendering to markup

Tests are passing, and I've successfully implemented it this way in my own project.  The only potential caveats at the moment:
- babel does not allow specifying the es3 target as far I can tell; this means using it with a client browser that needs es3 would require a shim
- The existing "types" option for strict types is likewise not something I see how to implement with babel, so it is ignored

Thoughts welcome.
